### PR TITLE
Bug fix in shortcut containers

### DIFF
--- a/modules/components/shortcut/Center.jsx
+++ b/modules/components/shortcut/Center.jsx
@@ -3,6 +3,6 @@ import Box from '../Box'
 
 export default class Center extends Component {
   render() {
-    return <Box {...props} center />
+    return <Box {...this.props} center />
   }
 }

--- a/modules/components/shortcut/Flex.jsx
+++ b/modules/components/shortcut/Flex.jsx
@@ -3,6 +3,6 @@ import Box from '../Box'
 
 export default class Flex extends Component {
   render() {
-    return <Box {...props} flex='1 0 auto' />
+    return <Box {...this.props} flex='1 0 auto' />
   }
 }

--- a/modules/components/shortcut/VBox.jsx
+++ b/modules/components/shortcut/VBox.jsx
@@ -3,6 +3,6 @@ import Box from '../Box'
 
 export default class VBox extends Component {
   render() {
-    return <Box {...props} column />
+    return <Box {...this.props} column />
   }
 }


### PR DESCRIPTION
See discussion in #23.
This PR replaces `{...props}` with `{...this.props}` Should fix VBox, Center, and Flex.

``` javascript
export default class VBox extends Component {
  render() {
    return <Box {...this.props} column />
  }
}
```
