### PR TITLE
Omit layout props

### DIFF
--- a/modules/components/Box.jsx
+++ b/modules/components/Box.jsx
@@ -1,20 +1,7 @@
 import React, { Component } from 'react'
 import prefixAll from 'inline-style-prefix-all'
 import warn from '../utils/warn'
-
-function omit(obj, omitions=[]) {
-  let newObj = {};
-
-  for (prop in obj) {
-    if (obj.hasOwnPropery(prop)) {
-      if (-1 === omitions.indexOf(prop)) {
-        newObj[prop] = obj[prop];
-      }
-    }
-  }
-
-  return newObj;
-}
+import omit from '../utils/omit'
 
 /**
  * Flexbox Component
@@ -27,11 +14,12 @@ export default class Box extends Component {
     const flexProps = ['flex', 'flexGrow', 'flexShrink', 'flexBasis']
     const boxProps = [...alignProps, ...sizeProps]
 
-    let layoutProps = boxProps.concat(flexProps).concat([
+    const layoutProps = [...boxProps, ...flexProps,
       'column', 'row', 'wrap', 'inline', 'center', 'fit'
-    ]);
+    ];
 
-    const props = omit(this.props, layoutProps);
+    const childProps = omit(this.props, layoutProps);
+    const props = this.props;
     const styles = {}
 
     // shortcut props
@@ -87,7 +75,7 @@ export default class Box extends Component {
     // processing styles and normalizing flexbox specifications
     const prefixedStyles = prefixAll(styles)
     const className = (props.className || '') + ' react-layout-components--box'
-    return <div {...props} className={ className } style={ {  ...prefixedStyles,  ...props.style} }>
+    return <div {...childProps} className={ className } style={ {  ...prefixedStyles,  ...props.style} }>
              { props.children }
            </div>
   }

--- a/modules/components/Box.jsx
+++ b/modules/components/Box.jsx
@@ -2,18 +2,36 @@ import React, { Component } from 'react'
 import prefixAll from 'inline-style-prefix-all'
 import warn from '../utils/warn'
 
+function omit(obj, omitions=[]) {
+  let newObj = {};
+
+  for (prop in obj) {
+    if (obj.hasOwnPropery(prop)) {
+      if (-1 === omitions.indexOf(prop)) {
+        newObj[prop] = obj[prop];
+      }
+    }
+  }
+
+  return newObj;
+}
+
 /**
  * Flexbox Component
  */
 export default class Box extends Component {
   render() {
-    const props = this.props
 
     const alignProps = ['order', 'justifyContent', 'alignItems', 'alignSelf', 'alignContent']
     const sizeProps = ['width', 'minWidth', 'maxWidth', 'height', 'minHeight', 'maxHeight']
     const flexProps = ['flex', 'flexGrow', 'flexShrink', 'flexBasis']
     const boxProps = [...alignProps, ...sizeProps]
 
+    let layoutProps = boxProps.concat(flexProps).concat([
+      'column', 'row', 'wrap', 'inline', 'center', 'fit'
+    ]);
+
+    const props = omit(this.props, layoutProps);
     const styles = {}
 
     // shortcut props

--- a/modules/utils/omit.js
+++ b/modules/utils/omit.js
@@ -1,0 +1,13 @@
+/**
+ * creates new object sans specified keys
+ * @param {object} obj
+ * @param {array|undefined} omitions
+ * @return {object}
+ */
+export default function omit(obj, omitions=[]) {
+  return Object.keys(obj).reduce((memo, key) => {
+    if (! omitions.includes(key)) memo[key] = obj[key];
+
+    return memo;
+  }, {});
+}

--- a/modules/utils/omit.js
+++ b/modules/utils/omit.js
@@ -6,7 +6,7 @@
  */
 export default function omit(obj, omitions=[]) {
   return Object.keys(obj).reduce((memo, key) => {
-    if (! omitions.includes(key)) memo[key] = obj[key];
+    if (-1 === omitions.indexOf(key)) memo[key] = obj[key];
 
     return memo;
   }, {});


### PR DESCRIPTION
This filters layout components to avoid warnings from native (e.g. DIV) components that don't expect them.

Notes:
- Rather than add a dependency, I used a naive re-implementation of lodash/underscore's omit.
- Please send notes on style, etc.
