### PR TITLE
Use independent prop-types package

### DIFF
--- a/modules/components/ScrollView.jsx
+++ b/modules/components/ScrollView.jsx
@@ -1,4 +1,5 @@
-import React, { PureComponent, PropTypes } from 'react'
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
 import { findDOMNode } from 'react-dom'
 
 import omit from '../utils/omit'

--- a/modules/components/TabView.jsx
+++ b/modules/components/TabView.jsx
@@ -1,4 +1,5 @@
-import React, { PureComponent, PropTypes } from 'react'
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
 import Box from './Box'
 
 /**

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "assign-styles": "^1.0.2",
-    "inline-style-prefixer": "^3.0.0"
+    "inline-style-prefixer": "^3.0.0",
+    "prop-types": "^15.5.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,7 +2130,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.7, prop-types@~15.5.7:
+prop-types@^15.5.10, prop-types@^15.5.7, prop-types@~15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:


### PR DESCRIPTION
Hi!

Here's a quick PR to fix "Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead."
As of react 15.5, accessing prototypes directly from the react package is deprecated.

Let me know if this is ok.