### PR TITLE
Add ref support to `Box`

### DIFF
--- a/modules/components/Box.jsx
+++ b/modules/components/Box.jsx
@@ -7,9 +7,8 @@ import { boxProps, flexProps, layoutProps } from '../utils/props'
 /**
  * Flexbox Component
  */
-class Box extends React.PureComponent {
-  render() {
-    const props = this.props
+const Box = React.memo(
+  React.forwardRef((props, ref) =>  {
     const styles = { }
 
     // shortcut props
@@ -67,11 +66,15 @@ class Box extends React.PureComponent {
     const childProps = omit(props, layoutProps)
 
     return (
-      <div {...childProps} className={className} style={{ ...prefixedStyles, ...props.style }}>
+      <div
+        {...childProps}
+        ref={ref}
+        className={className}
+        style={{ ...prefixedStyles, ...props.style }}>
         {props.children}
       </div>
     )
-  }
-}
+  })
+)
 
 export default Box

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "babel-preset-stage-0": "^6.1.18",
     "babelify": "^7.2.0",
     "browserify": "^11.0.1",
-    "react": "^14.0.0 || ^15.0.0",
-    "react-dom": "^14.0.0 || ^15.0.0"
+    "react": "^16.10.2",
+    "react-dom": "^16.10.2"
   },
   "dependencies": {
     "assign-styles": "^1.0.2",


### PR DESCRIPTION
Closes #52 

This PR adds ref support to `Box` using the forwardRef API provided in React 16.

According to the docs, this should be treated as a breaking change:

> _When you start using forwardRef in a component library, you should treat it as a breaking change and release a new major version of your library._

https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers

